### PR TITLE
Remove extraneous argument from call to reconcilePlayer

### DIFF
--- a/client/Simulator.js
+++ b/client/Simulator.js
@@ -57,7 +57,7 @@ class Simulator {
 		})
 
 		client.on('predictionErrorFrame', predictionErrorFrame => {
-			reconcilePlayer(predictionErrorFrame, this.client, this.myRawEntity, this.obstacles)
+			reconcilePlayer(predictionErrorFrame, this.client, this.myRawEntity)
 		})
 
 		this.input.onmousemove = (e) => {


### PR DESCRIPTION
Just a minor thing, `reconcilePlayer(predictionErrorFrame, client, entity)` takes 3 args, but is called with 4.