### PR TITLE
Add docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+/public/js
+/node_modules
+Dockerfile*
+docker-compose*
+/.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
-node_modules
+/node_modules
+/public/js
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:12 as builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . ./
+RUN npm run build
+
+# ---
+# For even smaller images.
+
+FROM node:12-slim
+
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --production
+
+COPY --from=builder /app/public /app/public/
+COPY server /app/server/
+COPY common /app/common/
+
+CMD ["node", "server/index.js"]

--- a/client/GameClient.js
+++ b/client/GameClient.js
@@ -12,7 +12,14 @@ class GameClient {
 
 		this.client.on('connected', res => { console.log('onConnect response:', res) })
 		this.client.on('disconnected', () => { console.log('connection closed') })
-		this.client.connect('ws://localhost:8079')
+
+		const proto = location.protocol === 'https:' ? 'wss:' : 'ws:'
+		const url = location.hostname === 'localhost' && location.port === "8080"
+			? 'ws://localhost:8079'
+			: `${proto}//${location.host}`
+
+		console.log("Connecting to:", url)
+		this.client.connect(url)
 	}
 
 	update(delta, tick, now) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3"
+services:
+  nengi:
+    build: .
+    environment:
+      - "PORT=5000"
+    ports:
+      - "5000:5000"

--- a/package-lock.json
+++ b/package-lock.json
@@ -470,8 +470,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
@@ -640,7 +639,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -790,8 +788,7 @@
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
-      "dev": true
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
     "cacache": {
       "version": "12.0.3",
@@ -1062,8 +1059,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -1907,6 +1903,21 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
+    },
+    "fast-url-parser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
+      "integrity": "sha1-9K8+qfNNiicc9YrSs3WfQx8LMY0=",
+      "requires": {
+        "punycode": "^1.3.2"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        }
+      }
     },
     "faye-websocket": {
       "version": "0.10.0",
@@ -3652,7 +3663,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -4212,8 +4222,7 @@
     "path-is-inside": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-      "dev": true
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
     },
     "path-key": {
       "version": "2.0.1",
@@ -4816,6 +4825,51 @@
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
       "integrity": "sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==",
       "dev": true
+    },
+    "serve-handler": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.2.tgz",
+      "integrity": "sha512-RFh49wX7zJmmOVDcIjiDSJnMH+ItQEvyuYLYuDBVoA/xmQSCuj+uRmk1cmBB5QQlI3qOiWKp6p4DUGY+Z5AB2A==",
+      "requires": {
+        "bytes": "3.0.0",
+        "content-disposition": "0.5.2",
+        "fast-url-parser": "1.1.3",
+        "mime-types": "2.1.18",
+        "minimatch": "3.0.4",
+        "path-is-inside": "1.0.2",
+        "path-to-regexp": "2.2.1",
+        "range-parser": "1.2.0"
+      },
+      "dependencies": {
+        "content-disposition": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+          "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+        },
+        "mime-db": {
+          "version": "1.33.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+          "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+        },
+        "mime-types": {
+          "version": "2.1.18",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+          "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+          "requires": {
+            "mime-db": "~1.33.0"
+          }
+        },
+        "path-to-regexp": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.2.1.tgz",
+          "integrity": "sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ=="
+        },
+        "range-parser": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+          "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+        }
+      }
     },
     "serve-index": {
       "version": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "babylonjs-loaders": "^4.0.3",
     "esm": "^3.2.25",
     "nengi": "^1.9.0",
+    "serve-handler": "^6.1.2",
     "xhr2": "^0.2.0"
   },
   "devDependencies": {

--- a/server/GameInstance.js
+++ b/server/GameInstance.js
@@ -16,14 +16,14 @@ import * as BABYLON from 'babylonjs'
 global.XMLHttpRequest = require('xhr2').XMLHttpRequest
 
 class GameInstance {
-	constructor() {
+	constructor(webConfig) {
 		const engine = new BABYLON.NullEngine()
 		engine.enableOfflineSupport = false
 		const scene = new BABYLON.Scene(engine)
 		scene.collisionsEnabled = true
 		//const camera = new BABYLON.ArcRotateCamera("Camera", 0, 0.8, 100, BABYLON.Vector3.Zero(), scene)
 
-		this.instance = new nengi.Instance(nengiConfig, { port: 8079 })
+		this.instance = new nengi.Instance(nengiConfig, webConfig)
 		niceInstanceExtension(this.instance)
 
 		// game-related state

--- a/server/serverMain.js
+++ b/server/serverMain.js
@@ -1,7 +1,20 @@
 import GameInstance from './GameInstance';
 import nengiConfig from '../common/nengiConfig';
+import * as http from 'http';
+import serveHandler from 'serve-handler'
 
-const gameInstance = new GameInstance(/*args*/)
+const port = process.env.PORT || 8079
+const httpServer = http.createServer((request, response) => {
+    return serveHandler(request, response, {
+        public: "public"
+    })
+})
+  
+httpServer.listen(port, () => {
+    console.log(`Listening on port ${port}`);
+});
+
+const gameInstance = new GameInstance({ httpServer })
 
 const hrtimeMs = function() {
     let time = process.hrtime()


### PR DESCRIPTION
Makes the server able to also serve the static files of the client.

Makes websocket url dynamic based on location (when not running in webpack dev server).

Makes server port configurable from env var.

Adds files for running in docker, including docker-compose file.